### PR TITLE
Add scaffolded multi-page web hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# episleep
+# Episleep · Base web Nuit de l'Info
+
+Structure HTML/CSS/JS minimaliste pour héberger les pages des défis. Tout est en static, prêt à être branché par chaque membre de l'équipe.
+
+## Arborescence
+- `assets/` : styles et scripts communs.
+- `pages/game/` : hub du jeu avec boutons Jouer, Paramètres, Crédits.
+- `pages/levels/` : sélection des niveaux avec scroll horizontal sur une grande image.
+- `projects/` : hub et pages dédiées aux défis (Femmes & Info, Décathlon, CVE Explorer, Ergonomie).
+
+## Accès rapide
+- Accueil : `/index.html`
+- Jeu : `/pages/game/index.html`
+- Carte des niveaux : `/pages/levels/index.html`
+- Hub Défis : `/projects/index.html`
+
+Le contenu est volontairement temporaire (lorem ipsum) pour faciliter les ajouts ultérieurs.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,0 +1,224 @@
+:root {
+  --bg: #0b132b;
+  --card: #1c2541;
+  --accent: #5bc0be;
+  --accent-2: #f7b801;
+  --text: #e0e6ed;
+  --muted: #9cb3c9;
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(91, 192, 190, 0.1), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(247, 184, 1, 0.15), transparent 30%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+header,
+footer {
+  background: rgba(28, 37, 65, 0.95);
+  border-bottom: 1px solid rgba(91, 192, 190, 0.25);
+  backdrop-filter: blur(6px);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+}
+
+.brand {
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  transition: all 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus-visible {
+  background: rgba(91, 192, 190, 0.12);
+  color: #fff;
+}
+
+nav a.active {
+  background: rgba(247, 184, 1, 0.18);
+  color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(247, 184, 1, 0.35);
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(91, 192, 190, 0.35), rgba(247, 184, 1, 0.25));
+  border: 1px solid rgba(91, 192, 190, 0.3);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+}
+
+.section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.18);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  border-radius: 14px;
+  border: none;
+  font-weight: 700;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #0b132b;
+  cursor: pointer;
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 10px;
+  background: rgba(91, 192, 190, 0.16);
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+.level-strip {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(90deg, rgba(91, 192, 190, 0.1), rgba(247, 184, 1, 0.08));
+}
+
+.level-track {
+  width: 2400px;
+  height: 260px;
+  background-image: url('https://images.unsplash.com/photo-1509228468518-180dd4864904?auto=format&fit=crop&w=2400&q=60');
+  background-size: cover;
+  background-repeat: repeat-x;
+  position: relative;
+}
+
+.level-marker {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 200px;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(28, 37, 65, 0.92);
+  border: 1px solid rgba(91, 192, 190, 0.35);
+  text-align: center;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.video-placeholder {
+  aspect-ratio: 16 / 9;
+  border: 2px dashed rgba(91, 192, 190, 0.5);
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  margin-bottom: 1rem;
+}
+
+.placeholder-img {
+  width: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.grid-two {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+blockquote {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-left: 4px solid var(--accent);
+  color: var(--muted);
+  border-radius: 10px;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,7 @@
+(function () {
+  const page = document.body.dataset.page;
+  const activeLink = document.querySelector(`[data-link="${page}"]`);
+  if (activeLink) {
+    activeLink.classList.add('active');
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hub Nuit de l'Info - Accueil</title>
+  <link rel="stylesheet" href="assets/css/base.css">
+  <script defer src="assets/js/main.js"></script>
+</head>
+<body data-page="home">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Structure prête à hacker à 8</p>
+      <h1>Bienvenue sur notre base web</h1>
+      <p>
+        Cette ossature légère en HTML/CSS/JS vous permet de décliner rapidement les pages des défis.
+        Le contenu est volontairement en mode brouillon (lorem ipsum) pour que chaque personne puisse
+        itérer sans friction.
+      </p>
+      <div class="button-row">
+        <a class="btn" href="/pages/game/index.html">Accéder au hub du jeu</a>
+        <a class="btn" href="/pages/levels/index.html">Voir la carte des niveaux</a>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <h2>Pages disponibles</h2>
+      <div class="section-grid">
+        <article class="card">
+          <h3>Accueil du jeu</h3>
+          <p>Entrée principale du jeu avec les actions Jouer, Paramètres et Crédits.</p>
+          <a class="btn" href="/pages/game/index.html">Ouvrir</a>
+        </article>
+        <article class="card">
+          <h3>Sélection des niveaux</h3>
+          <p>Vue horizontale défilante sur une grande image pour placer tous les niveaux.</p>
+          <a class="btn" href="/pages/levels/index.html">Ouvrir</a>
+        </article>
+        <article class="card">
+          <h3>Défis thématiques</h3>
+          <p>Pages prêtes pour chaque défi : Femmes &amp; Info, Décathlon, CVE Explorer, Ergonomie.</p>
+          <a class="btn" href="/projects/index.html">Explorer</a>
+        </article>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <h2>Répartition des défis</h2>
+      <div class="section-grid">
+        <article class="card">
+          <h3>Femmes &amp; Info</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse tincidunt et metus vitae posuere.</p>
+          <p class="tag">/projects/femmes-info</p>
+        </article>
+        <article class="card">
+          <h3>Décathlon</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non ipsum a ipsum placerat convallis.</p>
+          <p class="tag">/projects/decathlon</p>
+        </article>
+        <article class="card">
+          <h3>CVE Explorer</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus dictum, sem ac imperdiet blandit.</p>
+          <p class="tag">/projects/cve-explorer</p>
+        </article>
+        <article class="card">
+          <h3>Ergonomie &amp; Dark Patterns</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultricies sagittis commodo.</p>
+          <p class="tag">/projects/ergonomie</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Base web pour la Nuit de l'Info — à enrichir ensemble.</div>
+      <div>Direction artistique inspirée du défi « Oh les beaux boutons ».</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/game/index.html
+++ b/pages/game/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accueil du jeu</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="game">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Hub du jeu</p>
+      <h1>Accès rapide</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel sem sed lorem hendrerit gravida vel sed magna.</p>
+      <div class="button-row">
+        <button class="btn" type="button">Jouer</button>
+        <button class="btn" type="button">Paramètres</button>
+        <button class="btn" type="button">Crédits</button>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <h2>Notes pour l'équipe</h2>
+      <div class="grid-two">
+        <article class="card">
+          <h3>Découpage technique</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dictum leo eu hendrerit molestie.</p>
+          <blockquote>Point d'entrée pour intégrer le moteur de jeu ou une scène canvas.</blockquote>
+        </article>
+        <article class="card">
+          <h3>Actions principales</h3>
+          <ul>
+            <li>Jouer : redirigera vers la sélection de niveau.</li>
+            <li>Paramètres : panneau modal ou page dédiée.</li>
+            <li>Crédits : section avec les contributeurs.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Prototype jouable minimal — à brancher sur le moteur que vous choisirez.</div>
+      <div>À vous de brancher l'action des boutons.</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/pages/levels/index.html
+++ b/pages/levels/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carte des niveaux</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="levels">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Sélection horizontale</p>
+      <h1>Choisis ton niveau</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse placerat dui sit amet tortor malesuada pulvinar.</p>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <h2>Carte défilante</h2>
+      <div class="level-strip">
+        <div class="level-track">
+          <div class="level-marker" style="left: 80px;">Niveau 1</div>
+          <div class="level-marker" style="left: 420px;">Niveau 2</div>
+          <div class="level-marker" style="left: 760px;">Niveau 3</div>
+          <div class="level-marker" style="left: 1100px;">Niveau 4</div>
+          <div class="level-marker" style="left: 1440px;">Niveau 5</div>
+          <div class="level-marker" style="left: 1780px;">Niveau 6</div>
+          <div class="level-marker" style="left: 2120px;">Boss</div>
+        </div>
+      </div>
+      <p style="color: var(--muted); margin-top: 0.75rem;">Fais défiler horizontalement pour visualiser tous les niveaux.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Grande image prête à être remplacée par votre DA.</div>
+      <div>Ajoutez des ancres ou interactions au fil des niveaux.</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/projects/cve-explorer/index.html
+++ b/projects/cve-explorer/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Défi CVE Explorer</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="projects">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Défi CVE Explorer</p>
+      <h1>Interface API à esquisser</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin non urna commodo, aliquet lorem ac, feugiat lorem.</p>
+      <div class="button-row">
+        <a class="btn" href="https://www.nuitdelinfo.com/inscription/defis/505" target="_blank" rel="noreferrer">Brief officiel</a>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;" class="grid-two">
+      <article class="card">
+        <h2>Zone de formulaire</h2>
+        <p>Prévoir un champ pour saisir une CVE (ex: CVE-2023-12345) puis interroger l'API.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut imperdiet nisl eget velit blandit, sed porttitor magna sagittis.</p>
+      </article>
+      <article class="card">
+        <h2>Zone de résultats</h2>
+        <p>Liste ou carte pour présenter la description, le score CVSS, les références, etc.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id justo massa.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Wrapper API à brancher ici.</div>
+      <div>Prévoir une gestion d'erreurs utilisateur.</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/projects/decathlon/index.html
+++ b/projects/decathlon/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Défi Décathlon</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="projects">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Défi Décathlon</p>
+      <h1>Zone de préparation</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec urna diam. Mauris cursus, arcu in suscipit vehicula, urna nisl euismod dolor.</p>
+      <div class="button-row">
+        <a class="btn" href="https://www.nuitdelinfo.com/inscription/defis/497" target="_blank" rel="noreferrer">Brief officiel</a>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <div class="card">
+        <h2>Checklist rapide</h2>
+        <ul>
+          <li>Énumérer les parcours ou challenges Décathlon.</li>
+          <li>Ajouter des assets produits ou pictos sportifs.</li>
+          <li>Prévoir un lien retour vers la sélection de niveaux.</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Placeholder pour contenu sponsor ou storytelling.</div>
+      <div>Relier les sections au design « beaux boutons ».</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/projects/ergonomie/index.html
+++ b/projects/ergonomie/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Défi Ergonomie</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="projects">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Défi Ergonomie &amp; Dark Pattern</p>
+      <h1>Formulaire « difficile »</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam viverra augue nec diam sodales, id malesuada ante bibendum.</p>
+      <div class="button-row">
+        <a class="btn" href="https://www.nuitdelinfo.com/inscription/defis/444" target="_blank" rel="noreferrer">Brief officiel</a>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;" class="card">
+      <h2>Prototype de dark pattern</h2>
+      <p>Imaginez ici un formulaire déroutant (ex: boutons inversés, demandes répétitives). Le texte est provisoire.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ut lacus fringilla, semper elit nec, facilisis sapien.</p>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Zone pour expérimenter des interfaces piégeuses.</div>
+      <div>À rapprocher de la DA « beaux boutons ».</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/projects/femmes-info/index.html
+++ b/projects/femmes-info/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Défi Femmes & Info</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="projects">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Défi Femmes &amp; Info</p>
+      <h1>Support pour la page vidéo</h1>
+      <p>Placez ici la vidéo, l'image forte et le texte narratif. Le lorem ipsum actuel est là pour tenir la place.</p>
+      <div class="button-row">
+        <a class="btn" href="https://www.nuitdelinfo.com/inscription/defis/477" target="_blank" rel="noreferrer">Brief officiel</a>
+        <a class="btn" href="/">Retour accueil</a>
+      </div>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <div class="grid-two">
+        <article>
+          <div class="video-placeholder">Embed vidéo (à intégrer)</div>
+          <img class="placeholder-img" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=900&q=60" alt="Placeholder femmes et technologie">
+        </article>
+        <article class="card">
+          <h2>Lorem ipsum temporaire</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dictum ultricies nunc, at varius odio gravida eu. Cras ut hendrerit massa.</p>
+          <p>Fusce eu neque felis. Nulla facilisi. Vivamus ut ante commodo, dapibus eros nec, volutpat lorem. Donec pulvinar enim nibh, a pulvinar felis pharetra vitae.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Prévoir l'intégration de l'embed (YouTube, Vimeo...).</div>
+      <div>Zone image + texte pour mettre en avant les contributrices.</div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Défis - Hub</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script defer src="/assets/js/main.js"></script>
+</head>
+<body data-page="projects">
+  <header>
+    <div class="navbar">
+      <div class="brand">Nuit de l'Info · Hub</div>
+      <nav>
+        <ul>
+          <li><a href="/" data-link="home">Accueil</a></li>
+          <li><a href="/pages/game/index.html" data-link="game">Jeu</a></li>
+          <li><a href="/pages/levels/index.html" data-link="levels">Sélection des niveaux</a></li>
+          <li><a href="/projects/index.html" data-link="projects">Défis</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="tag">Espace projets</p>
+      <h1>Choisis un défi à développer</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tincidunt at libero vitae luctus.</p>
+    </section>
+
+    <section style="margin-top: 2rem;">
+      <div class="section-grid">
+        <article class="card">
+          <h3>Femmes &amp; Info</h3>
+          <p>Placeholder vidéo + image + texte.</p>
+          <a class="btn" href="/projects/femmes-info/index.html">Ouvrir la page</a>
+        </article>
+        <article class="card">
+          <h3>Décathlon</h3>
+          <p>Page de préparation avec checklist.</p>
+          <a class="btn" href="/projects/decathlon/index.html">Ouvrir la page</a>
+        </article>
+        <article class="card">
+          <h3>CVE Explorer</h3>
+          <p>Wrapper d'API pour afficher les données d'une CVE.</p>
+          <a class="btn" href="/projects/cve-explorer/index.html">Ouvrir la page</a>
+        </article>
+        <article class="card">
+          <h3>Ergonomie</h3>
+          <p>Formulaire volontairement piégeux / dark pattern.</p>
+          <a class="btn" href="/projects/ergonomie/index.html">Ouvrir la page</a>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-content">
+      <div>Défi « Oh les beaux boutons » : palette et gradients utilisés.</div>
+      <div>Ajoutez vos notes ici.</div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create shared styling and navigation for the Nuit de l'Info hub
- scaffold landing, game, level selection, and challenge pages with placeholder content
- add README notes on structure and quick links

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e1d2ebe083288e754562cd14f013)